### PR TITLE
Refactor Verification, add Alliance Total Verifications to TBA

### DIFF
--- a/app/admin-tools/form-accuracy/aggregations.ts
+++ b/app/admin-tools/form-accuracy/aggregations.ts
@@ -1,0 +1,108 @@
+import { TBATeamKey } from '@/lib/types/tba/utilTypes';
+import { StandFormI } from '@/models/StandForm';
+import { PipelineStage } from 'mongoose';
+
+export interface AllianceReportedTotals {
+	matchNumber: number;
+	alliance: 'red' | 'blue';
+	autoAmpNotes: number;
+	autoSpeakerNotes: number;
+	teleopAmpNotes: number;
+	teleopSpeakerNotes: number;
+	teleopAmplifiedSpeakerNotes: number;
+	trapNotes: number;
+	teamsReceived: number;
+	formsReceived: number;
+}
+
+// Get average of all reported fields on TBA, for use in verifying reported totals match the totals
+// on TBA
+export const allianceReportedTotals: PipelineStage[] = [
+	// Group by team number first to get average of all fields across forms for each team
+	{
+		$group: {
+			_id: {
+				teamNumber: '$teamNumber',
+				matchNumber: '$matchNumber',
+			},
+			autoAmpNotes: { $avg: '$autoAmpNotes' },
+			autoSpeakerNotes: {
+				$avg: '$autoSpeakerNotes',
+			},
+			alliance: { $first: '$alliance' },
+			teleopAmpNotes: {
+				$avg: '$teleopAmpNotes',
+			},
+			teleopAmplifiedSpeakerNotes: {
+				$avg: '$teleopAmplifiedSpeakerNotes',
+			},
+			trapNotes: { $avg: '$trapNotes' },
+			formsReceived: { $count: {} },
+		},
+	},
+	// Group by match number and alliance to get alliance totals
+	{
+		$group: {
+			_id: {
+				matchNumber: '$_id.matchNumber',
+				alliance: '$alliance',
+			},
+			autoAmpNotes: { $sum: '$autoAmpNotes' },
+			autoSpeakerNotes: {
+				$sum: '$autoSpeakerNotes',
+			},
+			teleopAmpNotes: {
+				$sum: '$teleopAmpNotes',
+			},
+			teleopSpeakerNotes: {
+				$sum: '$teleopSpeakerNotes',
+			},
+			teleopAmplifiedSpeakerNotes: {
+				$sum: '$teleopAmplifiedSpeakerNotes',
+			},
+			trapNotes: { $sum: '$trapNotes' },
+			teamsReceived: { $count: {} },
+			formsReceived: { $sum: '$formsReceived' },
+		},
+	},
+	{
+		$addFields: {
+			matchNumber: '$_id.matchNumber',
+			alliance: '$_id.alliance',
+		},
+	},
+	{ $unset: '_id' },
+];
+
+export interface TeamStandFormsByMatch {
+	teamKey: TBATeamKey;
+	matchNumber: number;
+	alliance: 'red' | 'blue';
+	forms: StandFormI[];
+}
+
+// Aggregate forms by match and team for use in verifying stand forms equal each other and match
+// TBA reported initiation line and endgame totals
+export const teamStandFormsByMatch: PipelineStage[] = [
+	{
+		$group: {
+			_id: {
+				matchNumber: '$matchNumber',
+				teamNumber: '$teamNumber',
+			},
+			alliance: { $first: '$alliance' },
+			forms: {
+				$push: '$$ROOT',
+			},
+		},
+	},
+	{
+		$addFields: {
+			matchNumber: '$_id.matchNumber',
+			teamKey: {
+				$concat: ['frc', { $toString: '$_id.teamNumber' }],
+			},
+		},
+	},
+	{ $unset: '_id' },
+];

--- a/app/admin-tools/form-accuracy/page.tsx
+++ b/app/admin-tools/form-accuracy/page.tsx
@@ -34,7 +34,9 @@ export default async function VerifyFormAccuracyPage() {
 	const [standFormsGroupedByTeamMatch, allianceTotals, tbaMatchesData] = await Promise.all([
 		StandForm.aggregate<TeamStandFormsByMatch>(teamStandFormsByMatch),
 		StandForm.aggregate<AllianceReportedTotals>(allianceReportedTotals),
-		getEventMatches(global.compKey.compKey as TBAEventKey, true),
+		getEventMatches(global.compKey.compKey as TBAEventKey, true).then((res) =>
+			res.filter((i) => i.comp_level === 'qm'),
+		),
 	]).catch(() => {
 		return [null, null, null];
 	});

--- a/app/admin-tools/form-accuracy/page.tsx
+++ b/app/admin-tools/form-accuracy/page.tsx
@@ -1,54 +1,23 @@
-import { connectToDbB } from '@/middleware/connect-db';
+import Link from 'next/link';
 import StandForm, { StandFormI } from '@/models/StandForm';
+import verifyAdmin from '@/middleware/app-router/verify-user';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cookies } from 'next/headers';
+import { connectToDbB } from '@/middleware/connect-db';
 import { getEventMatches } from '@/lib/fetchers/tba';
 import { TBAEventKey, TBATeamKey } from '@/lib/types/tba/utilTypes';
-import verifyAdmin from '@/middleware/app-router/verify-user';
-import { cookies } from 'next/headers';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import Link from 'next/link';
-
-const groupMatchesAgg = [
-	{
-		$group: {
-			_id: {
-				matchNumber: '$matchNumber',
-				teamNumber: '$teamNumber',
-			},
-			forms: { $push: '$$ROOT' },
-		},
-	},
-];
-
-interface GroupedForms {
-	_id: {
-		matchNumber: number;
-		teamNumber: number;
-	};
-	forms: StandFormI[];
-}
-
-function verifyFormEquality(ref: StandFormI, comp: StandFormI) {
-	if (ref.scoutScore !== comp.scoutScore) return false;
-	const keys: (keyof StandFormI)[] = [
-		'autoAmpNotes',
-		'autoSpeakerNotes',
-		'autoNotesMissed',
-		'teleopAmpNotes',
-		'teleopSpeakerNotes',
-		'teleopAmplifiedSpeakerNotes',
-		'teleopNotesMissed',
-		'shuttleNotes',
-		'trapNotes',
-		'trapAttempts',
-		'numberOnChain',
-	];
-	for (let key of keys) {
-		if (ref[key] !== comp[key]) {
-			return false;
-		}
-	}
-	return true;
-}
+import {
+	MatchNumberToMatch,
+	findAllianceErrors,
+	findFormsNotMatching,
+	findIndividualFormErrors,
+} from './utils';
+import {
+	AllianceReportedTotals,
+	TeamStandFormsByMatch,
+	allianceReportedTotals,
+	teamStandFormsByMatch,
+} from './aggregations';
 
 export default async function VerifyFormAccuracyPage() {
 	const access_token = cookies().get('access_token')?.value;
@@ -62,86 +31,41 @@ export default async function VerifyFormAccuracyPage() {
 		return <div>Current competition not set</div>;
 	}
 
-	const standFormGroups = await StandForm.aggregate<GroupedForms>(groupMatchesAgg);
-	// get completed tba matches
+	const [standFormsGroupedByTeamMatch, allianceTotals, tbaMatchesData] = await Promise.all([
+		StandForm.aggregate<TeamStandFormsByMatch>(teamStandFormsByMatch),
+		StandForm.aggregate<AllianceReportedTotals>(allianceReportedTotals),
+		getEventMatches(global.compKey.compKey as TBAEventKey, true),
+	]).catch(() => {
+		return [null, null, null];
+	});
 
-	const tbaMatchesData = await getEventMatches(global.compKey.compKey as TBAEventKey, true);
-	const matchNumMap = Object.fromEntries(
+	if (!standFormsGroupedByTeamMatch || !allianceTotals || !tbaMatchesData) {
+		return <div>Error fetching data</div>;
+	}
+
+	const matchNumMap: MatchNumberToMatch = Object.fromEntries(
 		tbaMatchesData.map((match) => [match.match_number.toString(), match]),
 	);
 
-	const mismatchedTeamMatches: { teamNumber: number; matchNumber: number }[] = [];
-	const mismatchedAutoLine: { teamNumber: number; matchNumber: number; _id: string }[] = [];
-	const mismatchedEndgameStatus: { teamNumber: number; matchNumber: number; _id: string }[] = [];
-	standFormGroups.forEach((standFormGroup) => {
-		if (standFormGroup.forms.length > 1) {
-			const reference = standFormGroup.forms[0];
-			standFormGroup.forms.slice(1).forEach((form) => {
-				if (!verifyFormEquality(reference, form)) {
-					mismatchedTeamMatches.push({ ...standFormGroup._id });
-					return;
-				}
-			});
-		}
-		const tbaMatchData = matchNumMap[standFormGroup._id.matchNumber];
-		if (tbaMatchData) {
-			let alliance: 'blue' | 'red' = 'blue';
-			let position = tbaMatchData.alliances.blue.team_keys.indexOf(
-				('frc' + standFormGroup._id.teamNumber) as TBATeamKey,
-			);
-			if (position === -1) {
-				alliance = 'red';
-				position = tbaMatchData.alliances.red.team_keys.indexOf(
-					('frc' + standFormGroup._id.teamNumber) as TBATeamKey,
-				);
-			}
-			const crossedAuto =
-				tbaMatchData.score_breakdown[alliance][
-					('autoLineRobot' + (position + 1)) as
-						| 'autoLineRobot1'
-						| 'autoLineRobot2'
-						| 'autoLineRobot3'
-				];
-			const EndgameStatus =
-				tbaMatchData.score_breakdown[alliance][
-					('endGameRobot' + (position + 1)) as
-						| 'endGameRobot1'
-						| 'endGameRobot2'
-						| 'endGameRobot3'
-				];
-			standFormGroup.forms.forEach((form) => {
-				if (
-					(form.initiationLine && crossedAuto === 'No') ||
-					(!form.initiationLine && crossedAuto === 'Yes')
-				) {
-					mismatchedAutoLine.push({
-						_id: form._id,
-						matchNumber: standFormGroup._id.matchNumber,
-						teamNumber: standFormGroup._id.teamNumber,
-					});
-				}
-				if (
-					(form.climb && (EndgameStatus === 'Parked' || EndgameStatus === 'None')) ||
-					(form.park && (EndgameStatus !== 'Parked')) ||
-					((!form.park && !form.climb) && (EndgameStatus !== 'None'))
-				) {
-					mismatchedEndgameStatus.push({
-						_id: form._id,
-						matchNumber: standFormGroup._id.matchNumber,
-						teamNumber: standFormGroup._id.teamNumber,
-					});
-				}
-			});
-		}
-	});
+	const mismatchedTeamMatches = findFormsNotMatching(standFormsGroupedByTeamMatch);
+	const { alliancesWithMismatchedFields, alliancesMissingTeams } = findAllianceErrors(
+		matchNumMap,
+		allianceTotals,
+	);
+	const individualFormErrors = findIndividualFormErrors(
+		standFormsGroupedByTeamMatch,
+		matchNumMap,
+	);
 
-	mismatchedAutoLine.sort((a, b) => a.matchNumber - b.matchNumber);
-	mismatchedEndgameStatus.sort((a, b) => a.matchNumber - b.matchNumber);
+	mismatchedTeamMatches.sort((a, b) => a.matchNumber - b.matchNumber);
+	individualFormErrors.sort((a, b) => a.matchNumber - b.matchNumber);
+	alliancesWithMismatchedFields.sort((a, b) => a.matchNumber - b.matchNumber);
+	alliancesMissingTeams.sort((a, b) => a.matchNumber - b.matchNumber);
 
 	return (
-		<main className='mx-auto mt-8 max-w-5xl px-4'>
+		<main className='mx-auto mt-8 max-w-5xl px-4 pb-16'>
 			<section>
-				<h2 className='typography'>Mismatched Forms</h2>
+				<h2 className='typography'>Mismatched Individual Forms</h2>
 				<div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
 					{mismatchedTeamMatches.map((i) => {
 						return (
@@ -149,24 +73,45 @@ export default async function VerifyFormAccuracyPage() {
 								<CardHeader className='p-6'>
 									<CardTitle>Match {i.matchNumber}</CardTitle>
 								</CardHeader>
-								<CardContent className='pt-0'>Team {i.teamNumber}</CardContent>
+								<CardContent className='pt-0'>
+									Team {i.teamNumber} <br />
+									<Link
+										className='text-primary hover:underline'
+										href={`/records/stand-forms/${i.idForm1}`}
+										target='_blank'
+									>
+										Form 1
+									</Link>{' '}
+									<br />
+									<Link
+										className='text-primary hover:underline'
+										href={`/records/stand-forms/${i.idForm2}`}
+										target='_blank'
+									>
+										Form 2
+									</Link>
+								</CardContent>
 							</Card>
 						);
 					})}
 				</div>
 			</section>
 			<section className='mt-4'>
-				<h2 className='typography'>Mismatched Auto Line with TBA</h2>
+				<h2 className='typography'>Individual Form Errors</h2>
 				<div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
-					{mismatchedAutoLine.map((i) => {
+					{individualFormErrors.map((i) => {
 						return (
 							<Card key={`${i.teamNumber} + ${i.matchNumber}`}>
 								<CardHeader className='p-6'>
-									<CardTitle>Match {i.matchNumber}</CardTitle>
+									<CardTitle>
+										Match {i.matchNumber} - Team {i.teamNumber}
+									</CardTitle>
 								</CardHeader>
 								<CardContent className='pt-0'>
-									Team {i.teamNumber}
-									<br />
+									<p>
+										<strong>Errors:</strong>
+										<br /> {i.errors.join(', ')}
+									</p>
 									<Link
 										className='text-primary hover:underline'
 										href={`/records/stand-forms/${i._id}`}
@@ -181,25 +126,45 @@ export default async function VerifyFormAccuracyPage() {
 				</div>
 			</section>
 			<section className='mt-4'>
-				<h2 className='typography'>Mismatched Endgame Status with TBA</h2>
-				<div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
-					{mismatchedEndgameStatus.map((i) => {
+				<h2 className='typography'>Mismatched Fields with TBA</h2>
+				<div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3'>
+					{alliancesWithMismatchedFields.map((i) => {
 						return (
-							<Card key={`${i.teamNumber} + ${i.matchNumber}`}>
+							<Card
+								key={`${i.matchNumber} + ${i.alliance === 'red' ? 'Red' : 'Blue'}`}
+							>
 								<CardHeader className='p-6'>
-									<CardTitle>Match {i.matchNumber}</CardTitle>
+									<CardTitle>
+										Match {i.matchNumber} -{' '}
+										{i.alliance === 'red' ? 'Red' : 'Blue'}
+									</CardTitle>
 								</CardHeader>
 								<CardContent className='pt-0'>
-									Team {i.teamNumber}
-									<br />
-									<Link
-										className='text-primary hover:underline'
-										href={`/records/stand-forms/${i._id}`}
-										target='_blank'
-									>
-										View Form
-									</Link>
+									<p>
+										<strong>Mismatched Fields:</strong>
+										<br /> {i.mismatchedFields.join(', ')}
+									</p>
 								</CardContent>
+							</Card>
+						);
+					})}
+				</div>
+			</section>
+			<section className='mt-4'>
+				<h2 className='typography'>Alliances Missing Teams</h2>
+				<div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3'>
+					{alliancesMissingTeams.map((i) => {
+						return (
+							<Card
+								key={`${i.matchNumber} + ${i.alliance === 'red' ? 'Red' : 'Blue'}`}
+							>
+								<CardHeader className='p-6'>
+									<CardTitle>
+										Match {i.matchNumber} -{' '}
+										{i.alliance === 'red' ? 'Red' : 'Blue'} Alliance
+									</CardTitle>
+								</CardHeader>
+								<CardContent className='pt-0'>Missing Team Data!</CardContent>
 							</Card>
 						);
 					})}

--- a/app/admin-tools/form-accuracy/utils.ts
+++ b/app/admin-tools/form-accuracy/utils.ts
@@ -1,0 +1,196 @@
+import { StandFormI } from '@/models/StandForm';
+import { AllianceReportedTotals, TeamStandFormsByMatch } from './aggregations';
+import { AllianceScoreBreakdown, EndgameStatus } from '@/lib/types/tba/score-breakdown';
+import TBAMatch from '@/lib/types/tba/match';
+import { TBATeamKey } from '@/lib/types/tba/utilTypes';
+
+const keysToCompare: (keyof StandFormI)[] = [
+	'autoAmpNotes',
+	'autoSpeakerNotes',
+	'autoNotesMissed',
+	'teleopAmpNotes',
+	'teleopSpeakerNotes',
+	'teleopAmplifiedSpeakerNotes',
+	'teleopNotesMissed',
+	'shuttleNotes',
+	'trapNotes',
+	'trapAttempts',
+	'numberOnChain',
+];
+
+export function verifyFormEquality(reference: StandFormI, comparison: StandFormI) {
+	// Check if the scout score is the same, if it's not we know right off the bat the forms are not equal
+	if (reference.scoutScore !== comparison.scoutScore) return false;
+	// Handle case where the scout score is the same, but the forms are not equal
+	for (let key of keysToCompare) {
+		if (reference[key] !== comparison[key]) {
+			return false;
+		}
+	}
+	// If all fields are the same, return true
+	return true;
+}
+
+const keyPairings: [keyof AllianceScoreBreakdown, keyof AllianceReportedTotals][] = [
+	['autoAmpNoteCount', 'autoAmpNotes'],
+	['autoSpeakerNoteCount', 'autoSpeakerNotes'],
+	['teleopAmpNoteCount', 'teleopAmpNotes'],
+	['teleopSpeakerNoteCount', 'teleopSpeakerNotes'],
+	['teleopSpeakerNoteAmplifiedCount', 'teleopAmplifiedSpeakerNotes'],
+];
+
+export type MatchNumberToMatch = {
+	[k: string]: TBAMatch;
+};
+
+function compareAllianceTotals(
+	tbaReported: AllianceScoreBreakdown,
+	scoutReported: AllianceReportedTotals,
+) {
+	const mismatchedKeys: (keyof AllianceReportedTotals)[] = [];
+	for (let [tbaKey, scoutKey] of keyPairings) {
+		if (tbaReported[tbaKey] !== scoutReported[scoutKey]) {
+			mismatchedKeys.push(scoutKey);
+		}
+	}
+	const tbaTrapNotes =
+		+tbaReported.trapCenterStage + +tbaReported.trapStageLeft + +tbaReported.trapStageRight;
+	if (tbaTrapNotes !== scoutReported.trapNotes) mismatchedKeys.push('trapNotes');
+	return mismatchedKeys;
+}
+
+interface AllianceReportedError {
+	matchNumber: number;
+	alliance: 'red' | 'blue';
+}
+
+interface MismatchedFields extends AllianceReportedError {
+	mismatchedFields: (keyof AllianceReportedTotals)[];
+}
+
+export function findAllianceErrors(
+	matchNumberToMatch: MatchNumberToMatch,
+	allianceReportedTotals: AllianceReportedTotals[],
+) {
+	const alliancesMissingTeams: AllianceReportedError[] = [];
+	const alliancesWithMismatchedFields: MismatchedFields[] = [];
+	for (let alliance of allianceReportedTotals) {
+		if (alliance.teamsReceived !== 3) {
+			alliancesMissingTeams.push({
+				matchNumber: alliance.matchNumber,
+				alliance: alliance.alliance,
+			});
+			continue;
+		}
+		const allianceColor = alliance.alliance;
+		const tbaAllianceScoreBreakdown =
+			matchNumberToMatch[alliance.matchNumber]?.score_breakdown?.[allianceColor];
+		if (!tbaAllianceScoreBreakdown) continue; // Skip if the match score not posted yet
+		const mismatchedKeys = compareAllianceTotals(tbaAllianceScoreBreakdown, alliance);
+		if (mismatchedKeys.length > 0)
+			alliancesWithMismatchedFields.push({
+				matchNumber: alliance.matchNumber,
+				alliance: allianceColor,
+				mismatchedFields: mismatchedKeys,
+			});
+	}
+	return { alliancesWithMismatchedFields, alliancesMissingTeams };
+}
+
+interface MismatchedForms {
+	matchNumber: number;
+	teamNumber: number;
+	idForm1: string;
+	idForm2: string;
+}
+
+export function findFormsNotMatching(forms: TeamStandFormsByMatch[]): MismatchedForms[] {
+	const formsNotMatching: MismatchedForms[] = [];
+	for (let teamMatchStandForms of forms) {
+		const reference = teamMatchStandForms.forms[0];
+		for (let i = 1; i < teamMatchStandForms.forms.length; i++) {
+			const comparison = teamMatchStandForms.forms[i];
+			if (!verifyFormEquality(reference, comparison)) {
+				formsNotMatching.push({
+					matchNumber: teamMatchStandForms.matchNumber,
+					teamNumber: parseInt(teamMatchStandForms.teamKey.slice(3)),
+					idForm1: reference._id,
+					idForm2: comparison._id,
+				});
+			}
+		}
+	}
+	return formsNotMatching;
+}
+
+function getTeamPosition(
+	teamKey: TBATeamKey,
+	alliance: 'red' | 'blue',
+	match: TBAMatch,
+): 1 | 2 | 3 {
+	const teamKeys = match.alliances[alliance].team_keys;
+	return (teamKeys.indexOf(teamKey) + 1) as 1 | 2 | 3;
+}
+
+interface IndividualFormError {
+	matchNumber: number;
+	teamNumber: number;
+	errors: string[];
+	_id: string;
+}
+
+function didClimbCorrectly(climb: boolean, park: boolean, tbaStatus: EndgameStatus) {
+	if (climb && ['StageRight', 'StageLeft', 'CenterStage'].includes(tbaStatus)) return true;
+	if (park && tbaStatus === 'Parked') return true;
+	if (!climb && !park && tbaStatus === 'None') return true;
+	return false;
+}
+
+export function findIndividualFormErrors(
+	forms: TeamStandFormsByMatch[],
+	matchNumberToMatch: MatchNumberToMatch,
+) {
+	const formErrors: IndividualFormError[] = [];
+	for (let groupedStandForm of forms) {
+		const allianceScoreBreakdown =
+			matchNumberToMatch[groupedStandForm.matchNumber]?.score_breakdown?.[
+				groupedStandForm.alliance
+			];
+		if (!allianceScoreBreakdown) continue; // Skip if the match score not posted yet
+		const teamPosition = getTeamPosition(
+			groupedStandForm.teamKey,
+			groupedStandForm.alliance,
+			matchNumberToMatch[groupedStandForm.matchNumber],
+		);
+		const autoLineKey = `autoLineRobot${teamPosition}` as
+			| 'autoLineRobot1'
+			| 'autoLineRobot2'
+			| 'autoLineRobot3';
+		const endGameRobotKey = `endGameRobot${teamPosition}` as
+			| 'endGameRobot1'
+			| 'endGameRobot2'
+			| 'endGameRobot3';
+		for (let form of groupedStandForm.forms) {
+			const errors: string[] = [];
+			if (
+				(form.initiationLine && allianceScoreBreakdown[autoLineKey] === 'No') ||
+				(!form.initiationLine && allianceScoreBreakdown[autoLineKey] === 'Yes')
+			) {
+				errors.push('autoLine');
+			}
+			if (
+				!didClimbCorrectly(form.climb, form.park, allianceScoreBreakdown[endGameRobotKey])
+			) {
+				errors.push('endgameStatus');
+			}
+			if (errors.length > 0)
+				formErrors.push({
+					matchNumber: groupedStandForm.matchNumber,
+					teamNumber: parseInt(groupedStandForm.teamKey.slice(3)),
+					errors,
+					_id: form._id,
+				});
+		}
+	}
+	return formErrors;
+}

--- a/app/api/spr/recompute/route.ts
+++ b/app/api/spr/recompute/route.ts
@@ -66,10 +66,10 @@ async function recomputeSPR() {
 		// Verify we have 6 forms for the alliance, if not ignore.
 		if (alliance.scoutScores.length === 6) {
 			const { matchNumber, alliance: color } = alliance._id;
-			const postResultTime = matches[matchNumber - 1]?.post_result_time;
-			if (postResultTime && postResultTime > 0) {
+			const breakdown = matches[matchNumber - 1]?.score_breakdown;
+			if (breakdown) {
 				const { scoutScoreMap, teamScoutMap } = buildScoutMaps(alliance.scoutScores);
-				const allianceBreakdown = matches[matchNumber - 1].score_breakdown[color];
+				const allianceBreakdown = breakdown[color];
 				const result = scoutExpectedContribution(
 					scoutScoreMap,
 					teamScoutMap,

--- a/components/ui/navbar/index.tsx
+++ b/components/ui/navbar/index.tsx
@@ -48,6 +48,7 @@ export default function Navbar({
 			urls: [
 				{ href: '/picklist', text: 'Picklist' },
 				{ href: '/spr', text: 'SPR' },
+				{ href: '/admin-tools/form-accuracy', text: 'Form Accuracy' },
 			],
 			adminOnly: true,
 		},

--- a/lib/fetchers/tba.ts
+++ b/lib/fetchers/tba.ts
@@ -26,7 +26,7 @@ export async function getEventMatches(
 		.then((res) => res.json())
 		.then((res: TBAMatch[]) => {
 			if (completedOnly) {
-				res = res.filter(({ actual_time }) => actual_time > 0);
+				res = res.filter(({ score_breakdown }) => score_breakdown !== null);
 			}
 			res.sort((a, b) => {
 				const [aSort, bSort] = [sortOrder[a.comp_level], sortOrder[b.comp_level]];

--- a/lib/types/tba/match.ts
+++ b/lib/types/tba/match.ts
@@ -20,7 +20,7 @@ export default interface TBAMatch {
 	match_number: number;
 	post_result_time: number | null;
 	predicted_time: number;
-	score_breakdown: ScoreBreakdown;
+	score_breakdown: ScoreBreakdown | null;
 	set_number: number;
 	time: number;
 	videos: TBAVideo[];

--- a/lib/types/tba/score-breakdown.ts
+++ b/lib/types/tba/score-breakdown.ts
@@ -1,7 +1,7 @@
 type AutoLine = 'Yes' | 'No';
-type EndgameStatus = 'None' | 'Parked' | 'StageRight' | 'StageLeft' | 'CenterStage';
+export type EndgameStatus = 'None' | 'Parked' | 'StageRight' | 'StageLeft' | 'CenterStage';
 
-interface AllianceScoreBreakdown {
+export interface AllianceScoreBreakdown {
 	adjustPoints: number;
 	autoAmpNoteCount: number;
 	autoAmpNotePoints: number;


### PR DESCRIPTION
This pull request adds additional verifications with TBA for alliances and refactors the current verifications.
- Makes existing aggregation easier to work with
- Add alliance verification aggregation (average team-match scores and then sum with alliance, cross-check totals with TBA)
- Add verification of alliance totals for verifiable fields
- Add missing team data check